### PR TITLE
Handle dual-register electricity tariffs

### DIFF
--- a/src/octopus_api.py
+++ b/src/octopus_api.py
@@ -45,6 +45,20 @@ def get_json(url: str, *, use_api_key: bool = False, timeout: int = DEFAULT_TIME
         response.raise_for_status()
     except requests.exceptions.HTTPError as exc:
         logger.error("Octopus API HTTP error for URL %s: status=%s", url, response.status_code)
-        raise OctopusApiError(f"API request failed with status {response.status_code}.") from exc
+        detail = _extract_error_detail(response)
+        message = f"API request failed with status {response.status_code}."
+        if detail:
+            message = f"{message} {detail}"
+        raise OctopusApiError(message) from exc
 
     return response.json()
+
+
+def _extract_error_detail(response):
+    try:
+        payload = response.json()
+    except ValueError:
+        return ""
+
+    detail = payload.get("detail")
+    return detail if isinstance(detail, str) else ""

--- a/src/price_logic.py
+++ b/src/price_logic.py
@@ -115,6 +115,8 @@ def build_dual_register_price_windows(
     night_rates,
     period_start,
     period_end,
+    # Octopus documents smart-meter Economy 7 off-peak as 00:30-07:30 UTC.
+    # https://octopus.energy/help-and-faqs/articles/what-is-an-economy-7-meter-and-tariff/
     night_start=time(0, 30),
     night_end=time(7, 30),
 ):

--- a/src/price_logic.py
+++ b/src/price_logic.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import datetime, time, timedelta, timezone
 
 
 def extract_product_code(selected_tariff_code):
@@ -106,6 +106,67 @@ def _calculate_weighted_average_price(prices, start, end):
         cursor = overlap_end
         if cursor >= end:
             return total_price_seconds / duration_seconds
+
+    return None
+
+
+def build_dual_register_price_windows(
+    day_rates,
+    night_rates,
+    period_start,
+    period_end,
+    night_start=time(0, 30),
+    night_end=time(7, 30),
+):
+    """
+    Expands day/night unit-rate records into the half-hour windows used by the chart.
+    The Economy 7 switching times are treated as UTC clock times.
+    """
+    current = _floor_to_half_hour(period_start.astimezone(timezone.utc))
+    period_end = period_end.astimezone(timezone.utc)
+    prices = []
+
+    while current < period_end:
+        next_slot = current + timedelta(minutes=30)
+        source_rates = night_rates if _is_night_slot(current, night_start, night_end) else day_rates
+        rate = _find_active_rate(source_rates, current)
+        if rate:
+            prices.append({
+                'valid_from': current.isoformat().replace("+00:00", "Z"),
+                'valid_to': next_slot.isoformat().replace("+00:00", "Z"),
+                'value_inc_vat': rate['value_inc_vat'],
+            })
+        current = next_slot
+
+    return prices
+
+
+def _floor_to_half_hour(value):
+    minute = 0 if value.minute < 30 else 30
+    return value.replace(minute=minute, second=0, microsecond=0)
+
+
+def _is_night_slot(value, night_start, night_end):
+    slot_time = value.time().replace(tzinfo=None)
+    if night_start <= night_end:
+        return night_start <= slot_time < night_end
+    return slot_time >= night_start or slot_time < night_end
+
+
+def _find_active_rate(rates, target):
+    for rate in rates:
+        try:
+            valid_from = datetime.fromisoformat(rate['valid_from'].replace('Z', '+00:00'))
+            valid_to = (
+                datetime.fromisoformat(rate['valid_to'].replace('Z', '+00:00'))
+                if rate.get('valid_to')
+                else datetime.max.replace(tzinfo=timezone.utc)
+            )
+        except (KeyError, ValueError, TypeError):
+            continue
+
+        if valid_from <= target < valid_to:
+            return rate
 
     return None
 

--- a/src/price_logic.py
+++ b/src/price_logic.py
@@ -126,12 +126,13 @@ def build_dual_register_price_windows(
     """
     current = _floor_to_half_hour(period_start.astimezone(timezone.utc))
     period_end = period_end.astimezone(timezone.utc)
+    day_rate = _representative_register_rate(day_rates, current, period_end)
+    night_rate = _representative_register_rate(night_rates, current, period_end)
     prices = []
 
     while current < period_end:
         next_slot = current + timedelta(minutes=30)
-        source_rates = night_rates if _is_night_slot(current, night_start, night_end) else day_rates
-        rate = _find_active_rate(source_rates, current)
+        rate = night_rate if _is_night_slot(current, night_start, night_end) else day_rate
         if rate:
             prices.append({
                 'valid_from': current.isoformat().replace("+00:00", "Z"),
@@ -155,22 +156,42 @@ def _is_night_slot(value, night_start, night_end):
     return slot_time >= night_start or slot_time < night_end
 
 
-def _find_active_rate(rates, target):
+def _representative_register_rate(rates, period_start, period_end):
+    parsed_rates = []
     for rate in rates:
-        try:
-            valid_from = datetime.fromisoformat(rate['valid_from'].replace('Z', '+00:00'))
-            valid_to = (
-                datetime.fromisoformat(rate['valid_to'].replace('Z', '+00:00'))
-                if rate.get('valid_to')
-                else datetime.max.replace(tzinfo=timezone.utc)
-            )
-        except (KeyError, ValueError, TypeError):
+        parsed = _parse_rate_window(rate)
+        if not parsed:
             continue
 
-        if valid_from <= target < valid_to:
-            return rate
+        valid_from, valid_to = parsed
+        if valid_from < period_end and period_start < valid_to:
+            parsed_rates.append((rate, valid_from, valid_to))
 
-    return None
+    if not parsed_rates:
+        return None
+
+    current_rate = next(
+        (rate for rate, valid_from, valid_to in parsed_rates if valid_from <= period_start < valid_to),
+        None,
+    )
+    if current_rate:
+        return current_rate
+
+    return min(parsed_rates, key=lambda item: item[1])[0]
+
+
+def _parse_rate_window(rate):
+    try:
+        valid_from = datetime.fromisoformat(rate['valid_from'].replace('Z', '+00:00'))
+        valid_to = (
+            datetime.fromisoformat(rate['valid_to'].replace('Z', '+00:00'))
+            if rate.get('valid_to')
+            else datetime.max.replace(tzinfo=timezone.utc)
+        )
+    except (KeyError, ValueError, TypeError):
+        return None
+
+    return valid_from, valid_to
 
 
 def build_region_to_tariffs_map(product_data, region_code_to_name):

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -13,7 +13,7 @@ import requests
 from gi.repository import Adw, Gdk, Gio, GLib, Gtk
 
 from ..octopus_api import OctopusApiError
-from ..price_logic import extract_product_code
+from ..price_logic import build_dual_register_price_windows, extract_product_code
 from ..price_logic import find_cheapest_slot as calculate_cheapest_slot
 from ..secrets_manager import get_api_key
 from ..usage_history import build_historical_usage_costs, fetch_recent_usage_samples, get_account_data
@@ -994,37 +994,15 @@ class MainWindow(Adw.ApplicationWindow):
                     auth = HTTPBasicAuth(api_key, '')
 
                 response = requests.get(rates_url, params={'page_size': 1500}, timeout=10, auth=auth)
-                if response.status_code == 401:
-                    GLib.idle_add(
-                        self._show_error_if_current,
-                        "The API key was rejected. Check the key in setup or Preferences.",
-                        request_id,
-                    )
+                if self._handle_tariff_fetch_error(response, request_id):
                     return
-                if response.status_code == 403:
-                    GLib.idle_add(
-                        self._show_error_if_current,
-                        "This tariff requires account access. Check your API key or choose another tariff.",
-                        request_id,
-                    )
-                    return
-                if response.status_code == 404:
-                    GLib.idle_add(
-                        self._show_error_if_current,
-                        "The selected tariff code was not found. Choose your tariff again in setup.",
-                        request_id,
-                    )
-                    return
-                response.raise_for_status()
-                data = response.json()
 
-                filtered_rates_dict = {
-                    rate['valid_from']: rate
-                    for rate in data.get('results', [])
-                    if (datetime.fromisoformat(rate['valid_to'].replace('Z', '+00:00')) -
-                        datetime.fromisoformat(rate['valid_from'].replace('Z', '+00:00'))) == timedelta(minutes=30)
-                }
-                raw_rates = sorted(filtered_rates_dict.values(), key=lambda x: x['valid_from'])
+                if self._is_dual_register_response(response):
+                    raw_rates = self._fetch_dual_register_rates(product_code, selected_tariff_code, now, auth)
+                else:
+                    response.raise_for_status()
+                    data = response.json()
+                    raw_rates = self._filter_half_hour_rates(data.get('results', []))
                 self.cache_manager.set(rates_cache_key, raw_rates)
 
             if not self._is_current_fetch(request_id):
@@ -1041,6 +1019,171 @@ class MainWindow(Adw.ApplicationWindow):
             import traceback
             traceback.print_exc()
             GLib.idle_add(self._show_error_if_current, f"An unexpected error occurred: {e}", request_id)
+
+    def _handle_tariff_fetch_error(self, response, request_id):
+        if response.status_code == 400 and self._is_dual_register_response(response):
+            return False
+        if response.status_code == 400:
+            detail = self._get_response_detail(response)
+            GLib.idle_add(
+                self._show_error_if_current,
+                detail or "The tariff API rejected the price data request.",
+                request_id,
+            )
+            return True
+        if response.status_code == 401:
+            GLib.idle_add(
+                self._show_error_if_current,
+                "The API key was rejected. Check the key in setup or Preferences.",
+                request_id,
+            )
+            return True
+        if response.status_code == 403:
+            GLib.idle_add(
+                self._show_error_if_current,
+                "This tariff requires account access. Check your API key or choose another tariff.",
+                request_id,
+            )
+            return True
+        if response.status_code == 404:
+            GLib.idle_add(
+                self._show_error_if_current,
+                "The selected tariff code was not found. Choose your tariff again in setup.",
+                request_id,
+            )
+            return True
+        return False
+
+    @staticmethod
+    def _is_dual_register_response(response):
+        if response.status_code != 400:
+            return False
+        detail = MainWindow._get_response_detail(response)
+        return "day and night rates" in detail.lower()
+
+    @staticmethod
+    def _get_response_detail(response):
+        try:
+            detail = response.json().get("detail", "")
+        except ValueError:
+            return ""
+        return detail if isinstance(detail, str) else ""
+
+    @staticmethod
+    def _filter_half_hour_rates(rates):
+        filtered_rates_dict = {
+            rate['valid_from']: rate
+            for rate in rates
+            if (datetime.fromisoformat(rate['valid_to'].replace('Z', '+00:00')) -
+                datetime.fromisoformat(rate['valid_from'].replace('Z', '+00:00'))) == timedelta(minutes=30)
+        }
+        return sorted(filtered_rates_dict.values(), key=lambda x: x['valid_from'])
+
+    def _fetch_dual_register_rates(self, product_code, tariff_code, now, auth):
+        logger.warning(
+            "Dual-register tariff detected for %s. Using provisional night window 00:30-07:30 UTC "
+            "while probing Octopus day/night endpoints for timestamp-specific behaviour.",
+            tariff_code,
+        )
+        day_rates = self._fetch_tariff_endpoint(product_code, tariff_code, "day-unit-rates", auth)
+        night_rates = self._fetch_tariff_endpoint(product_code, tariff_code, "night-unit-rates", auth)
+        self._log_dual_register_rate_summary("day-unit-rates", day_rates)
+        self._log_dual_register_rate_summary("night-unit-rates", night_rates)
+        self._probe_dual_register_specific_times(product_code, tariff_code, now, auth)
+        return build_dual_register_price_windows(
+            day_rates,
+            night_rates,
+            now - timedelta(days=1),
+            now + timedelta(days=4),
+        )
+
+    @staticmethod
+    def _fetch_tariff_endpoint(product_code, tariff_code, endpoint, auth, period_from=None, period_to=None):
+        url = f"https://api.octopus.energy/v1/products/{product_code}/electricity-tariffs/{tariff_code}/{endpoint}/"
+        params = {'page_size': 1500}
+        if period_from:
+            params['period_from'] = MainWindow._format_octopus_datetime(period_from)
+        if period_to:
+            params['period_to'] = MainWindow._format_octopus_datetime(period_to)
+        response = requests.get(url, params=params, timeout=10, auth=auth)
+        response.raise_for_status()
+        return response.json().get('results', [])
+
+    @staticmethod
+    def _format_octopus_datetime(value):
+        return value.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    @staticmethod
+    def _log_dual_register_rate_summary(endpoint, rates):
+        logger.warning("Octopus %s returned %d record(s).", endpoint, len(rates))
+        for rate in rates[:3]:
+            logger.warning(
+                "Octopus %s record: value_inc_vat=%s valid_from=%s valid_to=%s payment_method=%s",
+                endpoint,
+                rate.get("value_inc_vat"),
+                rate.get("valid_from"),
+                rate.get("valid_to"),
+                rate.get("payment_method"),
+            )
+
+    def _probe_dual_register_specific_times(self, product_code, tariff_code, now, auth):
+        probe_day = now.astimezone(timezone.utc).date()
+        probe_times = [
+            time(0, 0),
+            time(0, 30),
+            time(1, 30),
+            time(7, 0),
+            time(7, 30),
+            time(8, 30),
+        ]
+
+        logger.warning("Probing day/night unit-rate endpoints for specific half-hour windows on %s UTC.", probe_day)
+        for probe_time in probe_times:
+            slot_start = datetime.combine(probe_day, probe_time, tzinfo=timezone.utc)
+            slot_end = slot_start + timedelta(minutes=30)
+            try:
+                day_rates = self._fetch_tariff_endpoint(
+                    product_code,
+                    tariff_code,
+                    "day-unit-rates",
+                    auth,
+                    period_from=slot_start,
+                    period_to=slot_end,
+                )
+                night_rates = self._fetch_tariff_endpoint(
+                    product_code,
+                    tariff_code,
+                    "night-unit-rates",
+                    auth,
+                    period_from=slot_start,
+                    period_to=slot_end,
+                )
+            except requests.exceptions.RequestException as exc:
+                logger.warning(
+                    "Octopus dual-register probe failed for %s-%s UTC: %s",
+                    self._format_octopus_datetime(slot_start),
+                    self._format_octopus_datetime(slot_end),
+                    exc,
+                )
+                continue
+
+            logger.warning(
+                "Octopus dual-register probe %s-%s UTC: day=%s night=%s",
+                self._format_octopus_datetime(slot_start),
+                self._format_octopus_datetime(slot_end),
+                self._summarize_probe_rates(day_rates),
+                self._summarize_probe_rates(night_rates),
+            )
+
+    @staticmethod
+    def _summarize_probe_rates(rates):
+        if not rates:
+            return "no records"
+        rate = rates[0]
+        return (
+            f"{len(rates)} record(s), first value_inc_vat={rate.get('value_inc_vat')}, "
+            f"valid_from={rate.get('valid_from')}, valid_to={rate.get('valid_to')}"
+        )
 
     def _get_price_setup_issue(self):
         tariff_code = self.settings.get_string("selected-tariff-code")

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1080,16 +1080,8 @@ class MainWindow(Adw.ApplicationWindow):
         return sorted(filtered_rates_dict.values(), key=lambda x: x['valid_from'])
 
     def _fetch_dual_register_rates(self, product_code, tariff_code, now, auth):
-        logger.warning(
-            "Dual-register tariff detected for %s. Using provisional night window 00:30-07:30 UTC "
-            "while probing Octopus day/night endpoints for timestamp-specific behaviour.",
-            tariff_code,
-        )
         day_rates = self._fetch_tariff_endpoint(product_code, tariff_code, "day-unit-rates", auth)
         night_rates = self._fetch_tariff_endpoint(product_code, tariff_code, "night-unit-rates", auth)
-        self._log_dual_register_rate_summary("day-unit-rates", day_rates)
-        self._log_dual_register_rate_summary("night-unit-rates", night_rates)
-        self._probe_dual_register_specific_times(product_code, tariff_code, now, auth)
         return build_dual_register_price_windows(
             day_rates,
             night_rates,
@@ -1112,78 +1104,6 @@ class MainWindow(Adw.ApplicationWindow):
     @staticmethod
     def _format_octopus_datetime(value):
         return value.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-
-    @staticmethod
-    def _log_dual_register_rate_summary(endpoint, rates):
-        logger.warning("Octopus %s returned %d record(s).", endpoint, len(rates))
-        for rate in rates[:3]:
-            logger.warning(
-                "Octopus %s record: value_inc_vat=%s valid_from=%s valid_to=%s payment_method=%s",
-                endpoint,
-                rate.get("value_inc_vat"),
-                rate.get("valid_from"),
-                rate.get("valid_to"),
-                rate.get("payment_method"),
-            )
-
-    def _probe_dual_register_specific_times(self, product_code, tariff_code, now, auth):
-        probe_day = now.astimezone(timezone.utc).date()
-        probe_times = [
-            time(0, 0),
-            time(0, 30),
-            time(1, 30),
-            time(7, 0),
-            time(7, 30),
-            time(8, 30),
-        ]
-
-        logger.warning("Probing day/night unit-rate endpoints for specific half-hour windows on %s UTC.", probe_day)
-        for probe_time in probe_times:
-            slot_start = datetime.combine(probe_day, probe_time, tzinfo=timezone.utc)
-            slot_end = slot_start + timedelta(minutes=30)
-            try:
-                day_rates = self._fetch_tariff_endpoint(
-                    product_code,
-                    tariff_code,
-                    "day-unit-rates",
-                    auth,
-                    period_from=slot_start,
-                    period_to=slot_end,
-                )
-                night_rates = self._fetch_tariff_endpoint(
-                    product_code,
-                    tariff_code,
-                    "night-unit-rates",
-                    auth,
-                    period_from=slot_start,
-                    period_to=slot_end,
-                )
-            except requests.exceptions.RequestException as exc:
-                logger.warning(
-                    "Octopus dual-register probe failed for %s-%s UTC: %s",
-                    self._format_octopus_datetime(slot_start),
-                    self._format_octopus_datetime(slot_end),
-                    exc,
-                )
-                continue
-
-            logger.warning(
-                "Octopus dual-register probe %s-%s UTC: day=%s night=%s",
-                self._format_octopus_datetime(slot_start),
-                self._format_octopus_datetime(slot_end),
-                self._summarize_probe_rates(day_rates),
-                self._summarize_probe_rates(night_rates),
-            )
-
-    @staticmethod
-    def _summarize_probe_rates(rates):
-        if not rates:
-            return "no records"
-        rate = rates[0]
-        return (
-            f"{len(rates)} record(s), first value_inc_vat={rate.get('value_inc_vat')}, "
-            f"valid_from={rate.get('valid_from')}, valid_to={rate.get('valid_to')}"
-        )
 
     def _get_price_setup_issue(self):
         tariff_code = self.settings.get_string("selected-tariff-code")

--- a/src/usage_history.py
+++ b/src/usage_history.py
@@ -4,7 +4,7 @@ from urllib.parse import urlencode
 
 from .historical_costs import build_daily_costs, build_tariff_periods, get_usage_period
 from .octopus_api import OctopusApiError, get_json
-from .price_logic import extract_product_code
+from .price_logic import build_dual_register_price_windows, extract_product_code
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +31,7 @@ def fetch_recent_usage_samples(account_data):
                 continue
 
             mpan = meter_point.get("mpan")
+            _log_meter_point_probe(meter_point)
             best_samples = []
             for meter in meter_point.get("meters", []):
                 serial_number = meter.get("serial_number")
@@ -55,6 +56,7 @@ def fetch_recent_usage_samples(account_data):
                     logger.debug("Usage fetch failed for meter %s/%s: %s", mpan, serial_number, e)
                     continue
 
+                _log_usage_sample_probe(mpan, serial_number, samples)
                 if samples and len(samples) > len(best_samples):
                     best_samples = samples
 
@@ -92,10 +94,9 @@ def build_historical_usage_costs(account_data, usage_samples):
     standing_charges_by_tariff = {}
     for tariff_code in {period["tariff_code"] for period in tariff_periods}:
         product_code = extract_product_code(tariff_code)
-        rates_by_tariff[tariff_code] = fetch_historical_tariff_records(
+        rates_by_tariff[tariff_code] = fetch_historical_unit_rates(
             product_code,
             tariff_code,
-            "standard-unit-rates",
             period_start,
             period_end,
         )
@@ -108,6 +109,41 @@ def build_historical_usage_costs(account_data, usage_samples):
         )
 
     return build_daily_costs(usage_samples, tariff_periods, rates_by_tariff, standing_charges_by_tariff)
+
+
+def fetch_historical_unit_rates(product_code, tariff_code, period_start, period_end):
+    try:
+        return fetch_historical_tariff_records(
+            product_code,
+            tariff_code,
+            "standard-unit-rates",
+            period_start,
+            period_end,
+        )
+    except OctopusApiError as exc:
+        if "day and night rates" not in str(exc).lower():
+            raise
+
+    logger.warning(
+        "Historical usage costs for %s are using provisional dual-register expansion "
+        "with night window 00:30-07:30 UTC.",
+        tariff_code,
+    )
+    day_rates = fetch_historical_tariff_records(
+        product_code,
+        tariff_code,
+        "day-unit-rates",
+        period_start,
+        period_end,
+    )
+    night_rates = fetch_historical_tariff_records(
+        product_code,
+        tariff_code,
+        "night-unit-rates",
+        period_start,
+        period_end,
+    )
+    return build_dual_register_price_windows(day_rates, night_rates, period_start, period_end)
 
 
 def fetch_historical_tariff_records(product_code, tariff_code, endpoint, period_start, period_end):
@@ -145,6 +181,96 @@ def fetch_all_tariff_pages(initial_url):
 
 def _format_octopus_datetime(value):
     return value.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _log_meter_point_probe(meter_point):
+    mpan = meter_point.get("mpan")
+    meters = meter_point.get("meters", [])
+    agreements = meter_point.get("agreements", [])
+    active_tariff_codes = [agreement.get("tariff_code", "") for agreement in agreements]
+    register_fields = {
+        key: value
+        for key, value in meter_point.items()
+        if "register" in key.lower() or "profile" in key.lower() or "meter" in key.lower()
+    }
+    dual_register_tariffs = [
+        tariff_code
+        for tariff_code in active_tariff_codes
+        if isinstance(tariff_code, str) and "-2R-" in tariff_code.upper()
+    ]
+    logger.warning(
+        "Octopus account probe: active electricity meter point mpan=%s meters=%d agreements=%d keys=%s",
+        mpan,
+        len(meters),
+        len(agreements),
+        sorted(meter_point.keys()),
+    )
+    if dual_register_tariffs:
+        logger.warning(
+            "Octopus account probe: dual-register tariff agreement(s) detected for mpan=%s: %s",
+            mpan,
+            dual_register_tariffs,
+        )
+    if register_fields:
+        logger.warning("Octopus account probe: meter/register fields for mpan=%s: %s", mpan, register_fields)
+    else:
+        logger.warning(
+            "Octopus account probe: no obvious register/profile fields found directly on meter point mpan=%s.",
+            mpan,
+        )
+    for agreement in agreements:
+        logger.warning(
+            "Octopus account probe: agreement tariff_code=%s valid_from=%s valid_to=%s",
+            agreement.get("tariff_code"),
+            agreement.get("valid_from"),
+            agreement.get("valid_to"),
+        )
+    for meter in meters:
+        logger.warning(
+            "Octopus account probe: meter serial=%s keys=%s details=%s",
+            meter.get("serial_number"),
+            sorted(meter.keys()),
+            {
+                key: value
+                for key, value in meter.items()
+                if "register" in key.lower() or "profile" in key.lower() or "meter" in key.lower()
+            },
+        )
+        registers = meter.get("registers")
+        if registers is not None:
+            logger.warning(
+                "Octopus account probe: meter serial=%s registers=%s",
+                meter.get("serial_number"),
+                registers,
+            )
+        else:
+            logger.warning(
+                "Octopus account probe: meter serial=%s has no registers field in account payload.",
+                meter.get("serial_number"),
+            )
+
+
+def _log_usage_sample_probe(mpan, serial_number, samples):
+    logger.warning(
+        "Octopus usage probe: meter %s/%s returned %d consumption sample(s).",
+        mpan,
+        serial_number,
+        len(samples),
+    )
+    for sample in samples[:6]:
+        register_fields = {
+            key: value
+            for key, value in sample.items()
+            if "register" in key.lower() or "rate" in key.lower() or "cost" in key.lower()
+        }
+        logger.warning(
+            "Octopus usage probe: sample interval_start=%s interval_end=%s consumption=%s keys=%s register/rate/cost fields=%s",
+            sample.get("interval_start"),
+            sample.get("interval_end"),
+            sample.get("consumption"),
+            sorted(sample.keys()),
+            register_fields,
+        )
 
 
 def _has_active_agreement(meter_point, now):

--- a/src/usage_history.py
+++ b/src/usage_history.py
@@ -31,7 +31,6 @@ def fetch_recent_usage_samples(account_data):
                 continue
 
             mpan = meter_point.get("mpan")
-            _log_meter_point_probe(meter_point)
             best_samples = []
             for meter in meter_point.get("meters", []):
                 serial_number = meter.get("serial_number")
@@ -56,7 +55,6 @@ def fetch_recent_usage_samples(account_data):
                     logger.debug("Usage fetch failed for meter %s/%s: %s", mpan, serial_number, e)
                     continue
 
-                _log_usage_sample_probe(mpan, serial_number, samples)
                 if samples and len(samples) > len(best_samples):
                     best_samples = samples
 
@@ -124,11 +122,6 @@ def fetch_historical_unit_rates(product_code, tariff_code, period_start, period_
         if "day and night rates" not in str(exc).lower():
             raise
 
-    logger.warning(
-        "Historical usage costs for %s are using provisional dual-register expansion "
-        "with night window 00:30-07:30 UTC.",
-        tariff_code,
-    )
     day_rates = fetch_historical_tariff_records(
         product_code,
         tariff_code,
@@ -181,96 +174,6 @@ def fetch_all_tariff_pages(initial_url):
 
 def _format_octopus_datetime(value):
     return value.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-
-
-def _log_meter_point_probe(meter_point):
-    mpan = meter_point.get("mpan")
-    meters = meter_point.get("meters", [])
-    agreements = meter_point.get("agreements", [])
-    active_tariff_codes = [agreement.get("tariff_code", "") for agreement in agreements]
-    register_fields = {
-        key: value
-        for key, value in meter_point.items()
-        if "register" in key.lower() or "profile" in key.lower() or "meter" in key.lower()
-    }
-    dual_register_tariffs = [
-        tariff_code
-        for tariff_code in active_tariff_codes
-        if isinstance(tariff_code, str) and "-2R-" in tariff_code.upper()
-    ]
-    logger.warning(
-        "Octopus account probe: active electricity meter point mpan=%s meters=%d agreements=%d keys=%s",
-        mpan,
-        len(meters),
-        len(agreements),
-        sorted(meter_point.keys()),
-    )
-    if dual_register_tariffs:
-        logger.warning(
-            "Octopus account probe: dual-register tariff agreement(s) detected for mpan=%s: %s",
-            mpan,
-            dual_register_tariffs,
-        )
-    if register_fields:
-        logger.warning("Octopus account probe: meter/register fields for mpan=%s: %s", mpan, register_fields)
-    else:
-        logger.warning(
-            "Octopus account probe: no obvious register/profile fields found directly on meter point mpan=%s.",
-            mpan,
-        )
-    for agreement in agreements:
-        logger.warning(
-            "Octopus account probe: agreement tariff_code=%s valid_from=%s valid_to=%s",
-            agreement.get("tariff_code"),
-            agreement.get("valid_from"),
-            agreement.get("valid_to"),
-        )
-    for meter in meters:
-        logger.warning(
-            "Octopus account probe: meter serial=%s keys=%s details=%s",
-            meter.get("serial_number"),
-            sorted(meter.keys()),
-            {
-                key: value
-                for key, value in meter.items()
-                if "register" in key.lower() or "profile" in key.lower() or "meter" in key.lower()
-            },
-        )
-        registers = meter.get("registers")
-        if registers is not None:
-            logger.warning(
-                "Octopus account probe: meter serial=%s registers=%s",
-                meter.get("serial_number"),
-                registers,
-            )
-        else:
-            logger.warning(
-                "Octopus account probe: meter serial=%s has no registers field in account payload.",
-                meter.get("serial_number"),
-            )
-
-
-def _log_usage_sample_probe(mpan, serial_number, samples):
-    logger.warning(
-        "Octopus usage probe: meter %s/%s returned %d consumption sample(s).",
-        mpan,
-        serial_number,
-        len(samples),
-    )
-    for sample in samples[:6]:
-        register_fields = {
-            key: value
-            for key, value in sample.items()
-            if "register" in key.lower() or "rate" in key.lower() or "cost" in key.lower()
-        }
-        logger.warning(
-            "Octopus usage probe: sample interval_start=%s interval_end=%s consumption=%s keys=%s register/rate/cost fields=%s",
-            sample.get("interval_start"),
-            sample.get("interval_end"),
-            sample.get("consumption"),
-            sorted(sample.keys()),
-            register_fields,
-        )
 
 
 def _has_active_agreement(meter_point, now):

--- a/tests/test_price_logic.py
+++ b/tests/test_price_logic.py
@@ -5,7 +5,12 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
-from price_logic import build_region_to_tariffs_map, extract_product_code, find_cheapest_slot
+from price_logic import (
+    build_dual_register_price_windows,
+    build_region_to_tariffs_map,
+    extract_product_code,
+    find_cheapest_slot,
+)
 
 
 class PriceLogicTests(unittest.TestCase):
@@ -166,6 +171,56 @@ class PriceLogicTests(unittest.TestCase):
         }]
 
         self.assertIsNone(find_cheapest_slot(prices, now, duration_hours=1, start_within_hours=1))
+
+    def test_build_dual_register_price_windows_uses_night_rate_inside_window(self):
+        period_start = datetime(2026, 5, 13, 0, 0, tzinfo=timezone.utc)
+        period_end = datetime(2026, 5, 13, 8, 0, tzinfo=timezone.utc)
+        day_rates = [{
+            'valid_from': '2026-01-01T00:00:00Z',
+            'valid_to': None,
+            'value_inc_vat': 30.0,
+        }]
+        night_rates = [{
+            'valid_from': '2026-01-01T00:00:00Z',
+            'valid_to': None,
+            'value_inc_vat': 10.0,
+        }]
+
+        prices = build_dual_register_price_windows(day_rates, night_rates, period_start, period_end)
+
+        self.assertEqual(len(prices), 16)
+        self.assertEqual(prices[0]['value_inc_vat'], 30.0)
+        self.assertEqual(prices[1]['valid_from'], '2026-05-13T00:30:00Z')
+        self.assertEqual(prices[1]['value_inc_vat'], 10.0)
+        self.assertEqual(prices[14]['valid_from'], '2026-05-13T07:00:00Z')
+        self.assertEqual(prices[14]['value_inc_vat'], 10.0)
+        self.assertEqual(prices[15]['valid_from'], '2026-05-13T07:30:00Z')
+        self.assertEqual(prices[15]['value_inc_vat'], 30.0)
+
+    def test_build_dual_register_price_windows_uses_rate_valid_at_slot(self):
+        period_start = datetime(2026, 4, 1, 0, 0, tzinfo=timezone.utc)
+        period_end = datetime(2026, 4, 1, 1, 0, tzinfo=timezone.utc)
+        day_rates = [{
+            'valid_from': '2026-01-01T00:00:00Z',
+            'valid_to': None,
+            'value_inc_vat': 30.0,
+        }]
+        night_rates = [
+            {
+                'valid_from': '2026-01-01T00:00:00Z',
+                'valid_to': '2026-04-01T00:30:00Z',
+                'value_inc_vat': 12.0,
+            },
+            {
+                'valid_from': '2026-04-01T00:30:00Z',
+                'valid_to': None,
+                'value_inc_vat': 9.0,
+            },
+        ]
+
+        prices = build_dual_register_price_windows(day_rates, night_rates, period_start, period_end)
+
+        self.assertEqual([price['value_inc_vat'] for price in prices], [30.0, 9.0])
 
     def test_build_region_to_tariffs_map_prefers_direct_debit(self):
         product_data = {

--- a/tests/test_price_logic.py
+++ b/tests/test_price_logic.py
@@ -197,9 +197,9 @@ class PriceLogicTests(unittest.TestCase):
         self.assertEqual(prices[15]['valid_from'], '2026-05-13T07:30:00Z')
         self.assertEqual(prices[15]['value_inc_vat'], 30.0)
 
-    def test_build_dual_register_price_windows_uses_rate_valid_at_slot(self):
+    def test_build_dual_register_price_windows_uses_one_price_per_register(self):
         period_start = datetime(2026, 4, 1, 0, 0, tzinfo=timezone.utc)
-        period_end = datetime(2026, 4, 1, 1, 0, tzinfo=timezone.utc)
+        period_end = datetime(2026, 4, 1, 2, 0, tzinfo=timezone.utc)
         day_rates = [{
             'valid_from': '2026-01-01T00:00:00Z',
             'valid_to': None,
@@ -220,7 +220,8 @@ class PriceLogicTests(unittest.TestCase):
 
         prices = build_dual_register_price_windows(day_rates, night_rates, period_start, period_end)
 
-        self.assertEqual([price['value_inc_vat'] for price in prices], [30.0, 9.0])
+        self.assertEqual([price['value_inc_vat'] for price in prices], [30.0, 12.0, 12.0, 12.0])
+        self.assertEqual(sorted({price['value_inc_vat'] for price in prices}), [12.0, 30.0])
 
     def test_build_region_to_tariffs_map_prefers_direct_debit(self):
         product_data = {

--- a/tests/test_usage_history.py
+++ b/tests/test_usage_history.py
@@ -1,0 +1,43 @@
+import sys
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.octopus_api import OctopusApiError
+from src.usage_history import fetch_historical_unit_rates
+
+
+class UsageHistoryTests(unittest.TestCase):
+    def test_fetch_historical_unit_rates_expands_dual_register_tariff(self):
+        period_start = datetime(2026, 5, 13, 0, 0, tzinfo=timezone.utc)
+        period_end = datetime(2026, 5, 13, 1, 0, tzinfo=timezone.utc)
+        day_rates = [{
+            "valid_from": "2026-01-01T00:00:00Z",
+            "valid_to": None,
+            "value_inc_vat": 30.0,
+        }]
+        night_rates = [{
+            "valid_from": "2026-01-01T00:00:00Z",
+            "valid_to": None,
+            "value_inc_vat": 10.0,
+        }]
+
+        with patch("src.usage_history.fetch_historical_tariff_records") as fetch_records:
+            fetch_records.side_effect = [
+                OctopusApiError("API request failed with status 400. This tariff has day and night rates, not standard."),
+                day_rates,
+                night_rates,
+            ]
+
+            rates = fetch_historical_unit_rates("PRODUCT", "E-2R-PRODUCT-H", period_start, period_end)
+
+        self.assertEqual([rate["value_inc_vat"] for rate in rates], [30.0, 10.0])
+        self.assertEqual(fetch_records.call_args_list[1].args[2], "day-unit-rates")
+        self.assertEqual(fetch_records.call_args_list[2].args[2], "night-unit-rates")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #10 by handling Octopus dual-register electricity tariffs.

When the standard unit-rate endpoint reports that a tariff has day and night rates, the app now fetches the day and night unit-rate endpoints, expands them into the existing half-hour slot model and uses the documented Economy 7 night window of 00:30-07:30 UTC. The generated display data keeps one day price and one night price across the half-hour slots, so the chart remains compatible with the existing drawing path while showing the expected square-wave shape.

Also keeps the API error detail in the user-facing tariff failure path and applies the same dual-register expansion for historical usage cost lookup.